### PR TITLE
Adding more logging and enable Application Map

### DIFF
--- a/notifications/appsettings.json
+++ b/notifications/appsettings.json
@@ -8,7 +8,7 @@
   "CosmosDB": {
     "DatabaseName": "pxdraw",
     "CollectionName": "pixels",
-    "PollingInterval": 5,
+    "PollingInterval": 1,
     "PreferredLocations": "",
     "Endpoint": "",
     "MasterKey": ""


### PR DESCRIPTION
This PR adds extra logging to have telemetry on the duration of each dependency call and process time of each read loop.

Additionally, it lowers the default sleep time for non-active feeds to 1 second.