### PR TITLE
Adds user blocking features & moves user info to top level property

### DIFF
--- a/api/models/Pixel.cs
+++ b/api/models/Pixel.cs
@@ -15,9 +15,5 @@ namespace pxdraw.api.models
         public int Y { get; set; }
         [JsonProperty("color", Required = Required.Always)]
         public int Color { get; set; }
-        [JsonProperty("userId")]
-        public string UserId { get; set; }
-        [JsonProperty("lastUpdated")]
-        public DateTime LastUpdated { get; set; }
     }
 }

--- a/api/models/User.cs
+++ b/api/models/User.cs
@@ -15,6 +15,8 @@ namespace pxdraw.api.models
         public DateTime LastInsert { get; set; }
         [JsonProperty("isAdmin")]
         public bool IsAdmin { get; set; }
+        [JsonProperty("isBlocked")]
+        public bool IsBlocked { get; set; }
 
         public bool CanInsertPixel(int timeoutDurationInSeconds)
         {

--- a/api/services/PixelService.cs
+++ b/api/services/PixelService.cs
@@ -31,19 +31,21 @@ namespace pxdraw.api.services
             return _Singleton;
         }
 
-        public async Task Insert(Pixel[] pixels)
+        public async Task Insert(Pixel[] pixels, string userId, DateTime time)
         {
             var batches = CreateBatches(pixels);
             foreach(var batch in batches)
             {
-                await InsertBatch(batch);
+                await InsertBatch(batch, userId, time);
             }
         }
 
-        public async Task InsertBatch(Pixel[] pixels)
+        public async Task InsertBatch(Pixel[] pixels, string userId, DateTime time)
         {
             dynamic batch = new {
-                items = pixels
+                items = pixels,
+                userId,
+                time,
             };
 
             await _Client.CreateDocumentAsync(_CollectionUri, batch);


### PR DESCRIPTION
Users can now be blocked by setting the "isBlocked" property to true in Cosmos DB (TBD - add a first class API to block a given user by their ID, right now it's a manual DB operation).

User property is now a top level property on a batch insert, not a per pixel property (which should make stripping it from our APIs easier).

This does not strip the user id from the notification service. That needs to be done in a separate PR.