### PR TITLE
Hiding Change Feed attributes

### DIFF
--- a/notifications/ChangeFeed/ChangeFeedReader.cs
+++ b/notifications/ChangeFeed/ChangeFeedReader.cs
@@ -5,6 +5,7 @@
 namespace PxDRAW.SignalR.ChangeFeed
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
     using System.Net;
@@ -155,7 +156,13 @@ namespace PxDRAW.SignalR.ChangeFeed
                                 DateTimeOffset signalRDependencyStartTime = DateTimeOffset.UtcNow;
                                 try
                                 {
-                                    await this.signalRHubContext.Clients.All.SendAsync("Changes", JsonConvert.SerializeObject(results));
+                                    var response = results.Select((d) => new
+                                    {
+                                        items = d.GetPropertyValue<List<Pixel>>("items"),
+                                        _lsn = d.GetPropertyValue<long>("_lsn"),
+                                    });
+
+                                    await this.signalRHubContext.Clients.All.SendAsync("Changes", JsonConvert.SerializeObject(response));
                                     this.telemetryClient.TrackDependency("SignalR", "SendAsync", signalRDependencyStartTime, DateTimeOffset.UtcNow.Subtract(signalRDependencyStartTime), true);
                                 }
                                 catch (Exception ex)

--- a/notifications/Models/Pixel.cs
+++ b/notifications/Models/Pixel.cs
@@ -11,17 +11,9 @@ namespace PxDRAW.SignalR.Models
     {
         [JsonProperty("x", Required = Required.Always)]
         public int X { get; set; }
-
         [JsonProperty("y", Required = Required.Always)]
         public int Y { get; set; }
-
         [JsonProperty("color", Required = Required.Always)]
         public int Color { get; set; }
-
-        [JsonProperty("userId")]
-        public string UserId { get; set; }
-
-        [JsonProperty("lastUpdated")]
-        public DateTime LastUpdated { get; set; }
     }
 }

--- a/notifications/Models/Pixel.cs
+++ b/notifications/Models/Pixel.cs
@@ -1,0 +1,27 @@
+﻿// ----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
+// ----------------------------------------------------------------
+
+namespace PxDRAW.SignalR.Models
+{
+    using System;
+    using Newtonsoft.Json;
+
+    internal class Pixel
+    {
+        [JsonProperty("x", Required = Required.Always)]
+        public int X { get; set; }
+
+        [JsonProperty("y", Required = Required.Always)]
+        public int Y { get; set; }
+
+        [JsonProperty("color", Required = Required.Always)]
+        public int Color { get; set; }
+
+        [JsonProperty("userId")]
+        public string UserId { get; set; }
+
+        [JsonProperty("lastUpdated")]
+        public DateTime LastUpdated { get; set; }
+    }
+}


### PR DESCRIPTION
This PR filters the returned Feed response to only return the `items` and `_lsn` properties from the documents to the client.