### PR TITLE
Changing unit to milliseconds

### DIFF
--- a/notifications/ChangeFeed/ChangeFeedReader.cs
+++ b/notifications/ChangeFeed/ChangeFeedReader.cs
@@ -77,6 +77,11 @@ namespace PxDRAW.SignalR.ChangeFeed
                     PartitionKeyRangeId = "0",
                 };
 
+                if (this.cosmosDbConfiguration.MaxItemCount.HasValue)
+                {
+                    options.MaxItemCount = this.cosmosDbConfiguration.MaxItemCount.Value;
+                }
+
                 while (this.isRunning)
                 {
                     IDocumentQuery<Document> query = this.documentClient.CreateDocumentChangeFeedQuery(this.collectionLink, options);

--- a/notifications/ChangeFeed/ChangeFeedReader.cs
+++ b/notifications/ChangeFeed/ChangeFeedReader.cs
@@ -31,7 +31,7 @@ namespace PxDRAW.SignalR.ChangeFeed
         private const int DefaultMaxItemCount = 100;
 
         // Polling delay is used when there are no changes in the feed
-        private const int DefaultPollingIntervalInSeconds = 1;
+        private const int DefaultPollingIntervalInMilliseconds = 1000;
         private readonly TelemetryClient telemetryClient;
         private readonly CosmosDbConfiguration cosmosDbConfiguration;
         private bool isRunning = false;
@@ -67,7 +67,7 @@ namespace PxDRAW.SignalR.ChangeFeed
             }
 
             this.isRunning = true;
-            TimeSpan feedPollDelay = TimeSpan.FromSeconds(this.cosmosDbConfiguration.PollingInterval.HasValue ? this.cosmosDbConfiguration.PollingInterval.Value : DefaultPollingIntervalInSeconds);
+            TimeSpan feedPollDelay = TimeSpan.FromMilliseconds(this.cosmosDbConfiguration.PollingInterval.HasValue ? this.cosmosDbConfiguration.PollingInterval.Value : ChangeFeedReader.DefaultPollingIntervalInMilliseconds);
             return Task.Run(async () =>
             {
                 this.telemetryClient.TrackEvent($"ChangeFeedReader running.");

--- a/notifications/ChangeFeed/ChangeFeedReader.cs
+++ b/notifications/ChangeFeed/ChangeFeedReader.cs
@@ -31,7 +31,7 @@ namespace PxDRAW.SignalR.ChangeFeed
         private const int DefaultMaxItemCount = 100;
 
         // Polling delay is used when there are no changes in the feed
-        private const int DefaultPollingIntervalInMilliseconds = 1000;
+        private const int DefaultPollingIntervalInMilliseconds = 50;
         private readonly TelemetryClient telemetryClient;
         private readonly CosmosDbConfiguration cosmosDbConfiguration;
         private bool isRunning = false;

--- a/notifications/Models/CosmosDbConfiguration.cs
+++ b/notifications/Models/CosmosDbConfiguration.cs
@@ -18,6 +18,8 @@ namespace PxDRAW.SignalR.Models
 
         public int? PollingInterval { get; set; }
 
+        public int? MaxItemCount { get; set; }
+
         public string PreferredLocations { get; set; }
 
         public string[] ValidatedPreferredLocations

--- a/notifications/appsettings.json
+++ b/notifications/appsettings.json
@@ -8,7 +8,7 @@
   "CosmosDB": {
     "DatabaseName": "pxdraw",
     "CollectionName": "pixels",
-    "PollingInterval": 1000,
+    "PollingInterval": 50,
     "PreferredLocations": "",
     "Endpoint": "",
     "MasterKey": ""

--- a/notifications/appsettings.json
+++ b/notifications/appsettings.json
@@ -9,6 +9,7 @@
     "DatabaseName": "pxdraw",
     "CollectionName": "pixels",
     "PollingInterval": 50,
+    "MaxItemCount": 100,
     "PreferredLocations": "",
     "Endpoint": "",
     "MasterKey": ""

--- a/notifications/appsettings.json
+++ b/notifications/appsettings.json
@@ -8,7 +8,7 @@
   "CosmosDB": {
     "DatabaseName": "pxdraw",
     "CollectionName": "pixels",
-    "PollingInterval": 1,
+    "PollingInterval": 1000,
     "PreferredLocations": "",
     "Endpoint": "",
     "MasterKey": ""


### PR DESCRIPTION
This PR changes the `PollingInterval` configuration unit from seconds to milliseconds so it can be tuned lower than 1 second for idle watching.

It can be overriden by `CosmosDB:PollingInterval` or `CosmosDB__PollingInterval` according to the [ASP.NET Core configuration docs](https://docs.microsoft.com/aspnet/core/fundamentals/configuration/index?view=aspnetcore-2.1&tabs=basicconfiguration#configuration-by-environment).

Additionally, a new setting `MaxItemCount` was added to customize the batch size obtained from the Feed. Default value is 100.

It can be overriden by `CosmosDB:MaxItemCount` or `CosmosDB__MaxItemCount`.