### PR TITLE
Adding more operational logging

### DIFF
--- a/notifications/ChangeFeed/ChangeFeedReader.cs
+++ b/notifications/ChangeFeed/ChangeFeedReader.cs
@@ -129,6 +129,8 @@ namespace PxDRAW.SignalR.ChangeFeed
                             }
                             else if (dcex.Message.Contains("Reduce page size and try again."))
                             {
+                                this.telemetryClient.TrackEvent($"Page size error while reading the feed.");
+
                                 // Temporary workaround to compare exception message, until server provides better way of handling this case.
                                 if (!options.MaxItemCount.HasValue)
                                 {

--- a/notifications/ChangeFeed/ChangeFeedReader.cs
+++ b/notifications/ChangeFeed/ChangeFeedReader.cs
@@ -98,7 +98,6 @@ namespace PxDRAW.SignalR.ChangeFeed
                             this.telemetryClient.TrackMetric(new MetricTelemetry("CosmosDB.ChangeFeed.RU", readChangesResponse.RequestCharge));
                             this.telemetryClient.TrackDependency("CosmosDB.ChangeFeed", "ExecuteNextAsync", feedDependencyStartTime, DateTimeOffset.UtcNow.Subtract(feedDependencyStartTime), true);
                             options.RequestContinuation = readChangesResponse.ResponseContinuation;
-                            this.telemetryClient.TrackTrace($"Updating Continuation Token {options.RequestContinuation}.");
                         }
                         catch (DocumentClientException ex)
                         {

--- a/notifications/Models/Pixel.cs
+++ b/notifications/Models/Pixel.cs
@@ -4,15 +4,16 @@
 
 namespace PxDRAW.SignalR.Models
 {
-    using System;
     using Newtonsoft.Json;
 
     internal class Pixel
     {
         [JsonProperty("x", Required = Required.Always)]
         public int X { get; set; }
+
         [JsonProperty("y", Required = Required.Always)]
         public int Y { get; set; }
+
         [JsonProperty("color", Required = Required.Always)]
         public int Color { get; set; }
     }


### PR DESCRIPTION
Adds logs for thread sleep timers and RU charges.

Fixes random operational delays caused by `Flush` on AppInsights.