### PR TITLE
feature flag to block unauthenticated websocket usage

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -5,6 +5,7 @@ This is the client app for build demo.
 - `PXDRAW_METADATA_ENDPOINT`: sets the metadata endpoint that this app needs to talk to (defaults to localhost)
 - `PXDRAW_APPINSIGHTS_KEY`: sets the app insights key you want to use
 - `PXDRAW_REGION_LABEL`: sets the region label in the page title (defaults to "") (this is only used for the demo environments to show which region the site is in)
+- `PXDRAW_AUTHREQUIRED`: Set to "true" to force auth before initializing websocket connection. Defaults to false.
 
 ## Build the client
 

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,8 +1,10 @@
-declare var METADATA_ENDPOINT: string
+declare var METADATA_ENDPOINT: string;
+declare var AUTHREQUIRED: boolean;
 
 const config: AppConfig = {
     metadataEndpoint: METADATA_ENDPOINT,
-    isLocal: true
+    isLocal: true,
+    isAuthRequired: AUTHREQUIRED
 }
 
 if (window && window.location && window.location.hostname) {
@@ -38,6 +40,7 @@ export interface hostinfo {
 export interface AppConfig {
     metadataEndpoint: string;
     isLocal: boolean;
+    isAuthRequired: boolean;
 }
 
 export { config };

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -138,7 +138,9 @@ export class Main {
             console.log("User is not logged in");
         }
 
-        this.updateClient.init(this.websocketEndpoint);
+        if(!config.isAuthRequired || this.isLoggedIn()) {
+            this.updateClient.init(this.websocketEndpoint);
+        }
 
         // Periodic board update
         this.updateBoard();

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -21,7 +21,8 @@ module.exports = {
             }
         }),
         new webpack.DefinePlugin({
-            METADATA_ENDPOINT: JSON.stringify(process.env.PXDRAW_METADATA_ENDPOINT || "http://localhost:7071/api/metadata")
+            METADATA_ENDPOINT: JSON.stringify(process.env.PXDRAW_METADATA_ENDPOINT || "http://localhost:7071/api/metadata"),
+            AUTHREQUIRED: !!(process.env.PXDRAW_AUTHREQUIRED === "true" || false)
         })
     ]
 };


### PR DESCRIPTION
- Adds build flag to require auth for websockets
    - defaults to unauthenticated if the flag is missing
    - intended for the demo environments where we don't want unauthenticated users